### PR TITLE
添加新功能：获取当前帧图片bitmap

### DIFF
--- a/app/src/main/java/com/tencent/yolov8ncnn/YOLOv8Ncnn.java
+++ b/app/src/main/java/com/tencent/yolov8ncnn/YOLOv8Ncnn.java
@@ -23,7 +23,7 @@ public class YOLOv8Ncnn
     public native boolean openCamera(int facing);
     public native boolean closeCamera();
     public native boolean setOutputWindow(Surface surface);
-
+    public native Bitmap getCurrentFrame();
     static {
         System.loadLibrary("yolov8ncnn");
     }


### PR DESCRIPTION
添加了一个新的 JNI 方法 `getCurrentFrame`，允许应用程序获取当前相机捕获的图像帧作为 Android Bitmap 对象。这使得开发者可以：
- 获取实时相机预览中的帧数据
- 存储或处理检测到对象的图像
- 在 Android 应用中进一步处理图像数据
使用示例
在 Java 代码中，开发者现在可以调用：
Bitmap currentFrame = yolov8Ncnn.getCurrentFrame();

English:
Added a new JNI method getCurrentFrame that allows applications to retrieve the current camera frame as an Android Bitmap object. This enables developers to:

Access real-time camera preview frame data
Save or process images with detected objects
Further process image data in Android applications

Usage Example
In Java code, developers can now call:
Bitmap currentFrame = yolov8Ncnn.getCurrentFrame();